### PR TITLE
Fix expiration date formatting

### DIFF
--- a/app/src/main/java/com/vmware/nimbus/ui/main/DeploymentActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/main/DeploymentActivity.java
@@ -68,6 +68,7 @@ public class DeploymentActivity extends AppCompatActivity implements Serializabl
         }
 
         SimpleDateFormat sdfIn = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        SimpleDateFormat sdfInExpiration = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
         SimpleDateFormat sdfOut = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss a");
 
         Date createDate;
@@ -83,7 +84,7 @@ public class DeploymentActivity extends AppCompatActivity implements Serializabl
             updatedDate = sdfIn.parse(deploymentItem.lastUpdatedAt);
             goodUpdatedAt = sdfOut.format(updatedDate);
 
-            expireDate = sdfIn.parse(deploymentItem.leaseExpireAt);
+            expireDate = sdfInExpiration.parse(deploymentItem.leaseExpireAt);
             goodExpiresAt = sdfOut.format(expireDate);
         } catch (ParseException e) {
             e.printStackTrace();


### PR DESCRIPTION
For some reason, the expiration date is stored in a different format than the other dates. I fixed the formatting issue so now the expiration date is displayed.