### PR TITLE
Add resources card to deployments activity

### DIFF
--- a/app/src/main/java/com/vmware/nimbus/ui/main/DeploymentActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/main/DeploymentActivity.java
@@ -1,10 +1,14 @@
 package com.vmware.nimbus.ui.main;
 
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Bundle;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TableLayout;
+import android.widget.TableRow;
 import android.widget.TextView;
 
 import com.vmware.nimbus.R;
@@ -27,6 +31,7 @@ import androidx.fragment.app.DialogFragment;
 public class DeploymentActivity extends AppCompatActivity implements Serializable {
 
     DeploymentItemModel.DeploymentItem deploymentItem;
+    TableLayout resourcesLayout;
 
     /**
      * Called after the activity is created.
@@ -39,6 +44,46 @@ public class DeploymentActivity extends AppCompatActivity implements Serializabl
         setContentView(R.layout.activity_deployment);
         deploymentItem = (DeploymentItemModel.DeploymentItem) getIntent()
                 .getSerializableExtra("DeploymentItemModel.DeploymentItem");
+
+        resourcesLayout = findViewById(R.id.resources_layout);
+        for (int i = 0; i < deploymentItem.resources.size(); i++) {
+            TableRow typeRow = new TableRow(this);
+            TextView resourceTypeHeading = new TextView(this);
+            resourceTypeHeading.setText("Type: ");
+            resourceTypeHeading.setTextSize(12);
+            resourceTypeHeading.setTypeface(resourceTypeHeading.getTypeface(), Typeface.BOLD);
+            TextView resourceType = new TextView(this);
+            resourceType.setText(deploymentItem.resources.get(i).name);
+            resourceType.setTextSize(12);
+            typeRow.addView(resourceTypeHeading);
+            typeRow.addView(resourceType);
+            resourcesLayout.addView(typeRow);
+
+            TableRow nameRow = new TableRow(this);
+            TextView resourceNameHeading = new TextView(this);
+            resourceNameHeading.setText("Name: ");
+            resourceNameHeading.setTextSize(12);
+            resourceNameHeading.setTypeface(resourceNameHeading.getTypeface(), Typeface.BOLD);
+            TextView resourceName = new TextView(this);
+            resourceName.setText(deploymentItem.resources.get(i).name);
+            resourceName.setTextSize(12);
+            nameRow.addView(resourceNameHeading);
+            nameRow.addView(resourceName);
+            resourcesLayout.addView(nameRow);
+
+            TableRow statusRow = new TableRow(this);
+            TextView resourceStateHeading = new TextView(this);
+            resourceStateHeading.setText("Status: ");
+            resourceStateHeading.setTextSize(12);
+            resourceStateHeading.setTypeface(resourceStateHeading.getTypeface(), Typeface.BOLD);
+            TextView resourceState = new TextView(this);
+            resourceState.setText(deploymentItem.resources.get(i).properties.powerState);
+            resourceState.setTextSize(12);
+            statusRow.addView(resourceStateHeading);
+            statusRow.addView(resourceState);
+            statusRow.setPadding(0, 0, 0, 20);
+            resourcesLayout.addView(statusRow);
+        }
 
         TextView deploymentName = findViewById(R.id.deployment_name);
         TextView deploymentCreatedAt = findViewById(R.id.deployment_created_at);

--- a/app/src/main/res/layout/activity_deployment.xml
+++ b/app/src/main/res/layout/activity_deployment.xml
@@ -7,14 +7,14 @@
     android:layout_height="match_parent"
     android:orientation="vertical"
     android:paddingStart="20dp"
-    android:paddingTop="30dp"
+    android:paddingTop="20dp"
     android:paddingEnd="20dp"
     tools:context=".ui.main.DeploymentActivity">
 
     <androidx.cardview.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="20dp"
+        android:layout_margin="10dp"
         android:id="@+id/deployment_card"
         app:cardElevation="6dp"
         app:cardBackgroundColor="@color/cardview_light_background"
@@ -236,9 +236,53 @@
         </LinearLayout>
     </androidx.cardview.widget.CardView>
 
+    <androidx.cardview.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="150dp"
+        android:layout_marginLeft="10dp"
+        android:layout_marginRight="10dp"
+        android:layout_marginTop="10dp"
+        android:id="@+id/resources_card"
+        app:cardElevation="6dp">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="20dp"
+            android:layout_marginRight="20dp"
+            android:layout_marginTop="20dp"
+            android:layout_marginBottom="5dp"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/resources_heading"
+                android:layout_marginBottom="5dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:text="Resources"
+                android:textStyle="bold" />
+
+            <androidx.core.widget.NestedScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+                <TableLayout
+                    android:id="@+id/resources_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:layout_gravity="center">
+
+                </TableLayout>
+            </androidx.core.widget.NestedScrollView>
+        </LinearLayout>
+
+    </androidx.cardview.widget.CardView>
+
     <Button
         android:id="@+id/actions_button"
-        android:layout_width="match_parent"
+        android:layout_gravity="center_horizontal"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_margin="20dp"
         android:text="Actions"


### PR DESCRIPTION
User can view a scrollable list of resources details: type, name, and status.
Closes #94 
![image](https://user-images.githubusercontent.com/7535545/79701163-df225400-8268-11ea-9798-4e0759003f60.png)
