### PR TITLE
Changing the Login to use the same API URL

### DIFF
--- a/app/src/main/java/com/vmware/nimbus/api/APIService.java
+++ b/app/src/main/java/com/vmware/nimbus/api/APIService.java
@@ -2,6 +2,8 @@ package com.vmware.nimbus.api;
 
 import android.annotation.TargetApi;
 import android.content.Context;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -113,7 +115,7 @@ public class APIService {
      * @param c - the Context
      */
     public static void loadBlueprints(final BlueprintCallback callback, Context c) {
-        blueprintsUrl = c.getApplicationContext().getResources().getString(R.string.blueprints_url);
+        blueprintsUrl = getBaseEndpointURL(c) + c.getApplicationContext().getResources().getString(R.string.blueprints_uri);
         StringRequest jsonObjRequest = new StringRequest(
                 Request.Method.GET,
                 blueprintsUrl,
@@ -151,7 +153,7 @@ public class APIService {
      * @param callback - callback that watches for successful deployments data from the response
      */
     public static void loadDeployments(final DeploymentCallback callback, Context c) {
-        deploymentsUrl = c.getApplicationContext().getResources().getString(R.string.deployments_url);
+        deploymentsUrl = getBaseEndpointURL(c) + c.getApplicationContext().getResources().getString(R.string.deployments_uri);
         StringRequest jsonObjRequest = new StringRequest(
                 Request.Method.GET,
                 deploymentsUrl,
@@ -200,7 +202,7 @@ public class APIService {
         Gson gson = new Gson();
         String json = gson.toJson(requestBody);
         JSONObject jsonObject = new JSONObject(json);
-        bpRequestUrl = c.getApplicationContext().getResources().getString(R.string.bp_request_url);
+        bpRequestUrl = getBaseEndpointURL(c) + c.getApplicationContext().getResources().getString(R.string.bp_request_uri);
         JsonObjectRequest jsonObjRequest = new JsonObjectRequest(Request.Method.POST, bpRequestUrl, jsonObject,
                 new Response.Listener<JSONObject>() {
                     @Override
@@ -300,5 +302,15 @@ public class APIService {
     public static void toastMsg(String msg, Context c) {
         Toast toast = Toast.makeText(c, msg, Toast.LENGTH_LONG);
         toast.show();
+    }
+
+    /**
+     * Get the base endpoint URL from the application's settings or get the default if not present
+     * @param context Application Context
+     * @return The base URL without the trailing slash
+     */
+    public static String getBaseEndpointURL(Context context) {
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(context.getApplicationContext());
+        return settings.getString("base_url", context.getApplicationContext().getResources().getString(R.string.base_url));
     }
 }

--- a/app/src/main/java/com/vmware/nimbus/data/model/CspResult.java
+++ b/app/src/main/java/com/vmware/nimbus/data/model/CspResult.java
@@ -2,44 +2,19 @@ package com.vmware.nimbus.data.model;
 
 public class CspResult {
 
-    private String id_token;
-    private String token_type;
-    private String scope;
-    private String access_token;
-    private String refresh_token;
+    private String tokenType;
+    private String token;
 
-    private int expires_in;
-
-    public CspResult(String id_token, String token_type, String scope, String access_token, String refresh_token, int expires_in) {
-        this.id_token = id_token;
-        this.token_type = token_type;
-        this.scope = scope;
-        this.access_token = access_token;
-        this.refresh_token = refresh_token;
-        this.expires_in = expires_in;
+    public CspResult(String tokenType, String token) {
+        this.token = token;
+        this.tokenType = tokenType;
     }
 
-    public String getId_token() {
-        return id_token;
+    public String getTokenType() {
+        return tokenType;
     }
 
-    public String getToken_type() {
-        return token_type;
-    }
-
-    public String getScope() {
-        return scope;
-    }
-
-    public String getAccess_token() {
-        return access_token;
-    }
-
-    public String getRefresh_token() {
-        return refresh_token;
-    }
-
-    public int getExpires_in() {
-        return expires_in;
+    public String getToken() {
+        return token;
     }
 }

--- a/app/src/main/java/com/vmware/nimbus/ui/login/LoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/LoginActivity.java
@@ -54,7 +54,7 @@ public class LoginActivity extends AppCompatActivity {
             public void onClick(View v) {
                 loadingProgressBar.setVisibility(View.VISIBLE);
 
-                APIService.LogIn(getBaseContext(), getResources().getString(R.string.csp_URL),
+                APIService.LogIn(getBaseContext(), APIService.getBaseEndpointURL(getBaseContext()) + getResources().getString(R.string.login_uri),
                         apiKeyEditText.getText().toString(), new LogInCallback() {
                             @Override
                             public void onSuccess(boolean result) {

--- a/app/src/main/java/com/vmware/nimbus/ui/main/fragments/DeploymentActionsFragment.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/main/fragments/DeploymentActionsFragment.java
@@ -23,6 +23,7 @@ import com.android.volley.VolleyError;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.google.gson.Gson;
 import com.vmware.nimbus.R;
+import com.vmware.nimbus.api.APIService;
 import com.vmware.nimbus.api.SingletonRequest;
 import com.vmware.nimbus.data.model.LoginModel;
 
@@ -225,7 +226,7 @@ public class DeploymentActionsFragment extends DialogFragment {
      * @throws JSONException
      */
     public void performDeploymentAction(DeploymentActionRequest request) throws JSONException {
-        baseUrl = c.getApplicationContext().getResources().getString(R.string.deployments_base_url);
+        baseUrl = APIService.getBaseEndpointURL(c) + c.getApplicationContext().getResources().getString(R.string.deployments_base_uri);
         String requestUrl = baseUrl + deploymentId + "/requests";
         Log.d(LOG_TAG, "Request URL: " + requestUrl);
         Gson gson = new Gson();

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,9 +29,10 @@
 
     <string name="contact_dev">Contact the Dev Team</string>
 
-    <string name="csp_URL">https://api.mgmt.cloud.vmware.com/iaas/login</string>
-    <string name="blueprints_url">https://api.mgmt.cloud.vmware.com/blueprint/api/blueprints</string>
-    <string name="deployments_url">https://api.mgmt.cloud.vmware.com/deployment/api/deployments?expand=resources</string>
-    <string name="bp_request_url">https://api.mgmt.cloud.vmware.com/blueprint/api/blueprint-requests</string>
-    <string name="deployments_base_url">https://api.mgmt.cloud.vmware.com/deployment/api/deployments/</string>
+    <string name="base_url">https://api.mgmt.cloud.vmware.com</string>
+    <string name="login_uri">/iaas/login</string>
+    <string name="blueprints_uri">/blueprint/api/blueprints</string>
+    <string name="deployments_uri">/deployment/api/deployments?expand=resources</string>
+    <string name="bp_request_uri">/blueprint/api/blueprint-requests</string>
+    <string name="deployments_base_uri">/deployment/api/deployments/</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
 
     <string name="contact_dev">Contact the Dev Team</string>
 
-    <string name="csp_URL">https://console.cloud.vmware.com/csp/gateway/am/api/auth/api-tokens/authorize</string>
+    <string name="csp_URL">https://api.mgmt.cloud.vmware.com/iaas/login</string>
     <string name="blueprints_url">https://api.mgmt.cloud.vmware.com/blueprint/api/blueprints</string>
     <string name="deployments_url">https://api.mgmt.cloud.vmware.com/deployment/api/deployments?expand=resources</string>
     <string name="bp_request_url">https://api.mgmt.cloud.vmware.com/blueprint/api/blueprint-requests</string>


### PR DESCRIPTION
Make logging in and api calls use the same URL so that we can more
easily switch vRA endpoints in the future