### PR TITLE
Adding csp login using Android WebView

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <bytecodeTargetLevel target="1.8" />
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
             android:name=".ui.login.CSPLoginActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
+            android:windowSoftInputMode= "adjustPan"
             android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name=".ui.main.OptionsActivity"></activity>
+        <activity android:name=".ui.login.TokenLoginActivity"></activity>
+        <activity android:name=".ui.main.OptionsActivity" />
         <activity android:name=".ui.main.DeploymentActivity" />
         <activity android:name=".ui.main.BlueprintActivity" />
         <activity
@@ -24,7 +25,7 @@
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar" />
         <activity
-            android:name=".ui.login.LoginActivity"
+            android:name=".ui.login.CSPLoginActivity"
             android:label="@string/app_name"
             android:screenOrientation="portrait"
             android:theme="@style/AppTheme.NoActionBar">

--- a/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
@@ -7,18 +7,31 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.util.Log;
 import android.view.View;
+import android.webkit.CookieManager;
+import android.webkit.ValueCallback;
+import android.webkit.WebResourceRequest;
+import android.webkit.WebSettings;
+import android.webkit.WebStorage;
 import android.webkit.WebView;
+import android.webkit.WebViewClient;
 import android.widget.Button;
-import android.widget.EditText;
-import android.widget.ProgressBar;
 import android.widget.Toast;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.vmware.nimbus.R;
+import com.vmware.nimbus.data.model.CspResult;
+import com.vmware.nimbus.data.model.LoginModel;
 import com.vmware.nimbus.ui.main.MainActivity;
 import com.vmware.nimbus.ui.main.OptionsActivity;
 
 public class CSPLoginActivity extends AppCompatActivity {
+
+    Integer targetUrlHitCount;
+    Boolean loaded;
+    Intent mainIntent;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -27,7 +40,20 @@ public class CSPLoginActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_csplogin);
 
+        mainIntent = new Intent(this, MainActivity.class);
+        targetUrlHitCount = 0;
+        loaded = false;
+
+        // create WebView, clear local storage and cookies
         WebView cspLoginPage = (WebView) findViewById(R.id.webview);
+        WebStorage.getInstance().deleteAllData();
+        CookieManager.getInstance().removeAllCookies(null);
+
+        // allow storage and javascript, set Webview Client
+        WebSettings websettings = cspLoginPage.getSettings();
+        websettings.setDomStorageEnabled(true);
+        websettings.setJavaScriptEnabled(true);
+        cspLoginPage.setWebViewClient(new MyBrowser());
         cspLoginPage.loadUrl("https://www.mgmt.cloud.vmware.com/catalog/#/library");
 
         Intent optionsIntent = new Intent(this, OptionsActivity.class);
@@ -56,4 +82,79 @@ public class CSPLoginActivity extends AppCompatActivity {
             finish();
         }
     }
+
+    /**
+     * Wrapper for Toast class.
+     *
+     * @param msg - the message to Toast
+     */
+    public void toastMsg(String msg) {
+        Toast toast = Toast.makeText(getApplicationContext(), msg, Toast.LENGTH_LONG);
+        toast.show();
+    }
+
+    private class MyBrowser extends WebViewClient {
+        // allow redirect
+        @Override
+        public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+            String uri = request.getUrl().toString();
+            view.loadUrl(uri);
+            return false;
+        }
+
+        @Override
+        public void onPageFinished(WebView view, String url) {
+            // allow 2 hits to library before redirecting
+            if ("https://www.mgmt.cloud.vmware.com/catalog/#/library".equals(url)) {
+                targetUrlHitCount = targetUrlHitCount + 1;
+                Log.d("CspLoginUrlHitCount", String.format("targetUrlHitCount: %s",targetUrlHitCount));
+                if (targetUrlHitCount == 2) {
+                    view.setVisibility(View.GONE);
+                    view.loadUrl("https://api.mgmt.cloud.vmware.com/provisioning/access-token");
+                }
+            }
+
+            if ("https://api.mgmt.cloud.vmware.com/provisioning/access-token".equals(url) && loaded) {
+                view.evaluateJavascript("document.body.innerText", new ValueCallback<String>() {
+                    @Override
+                    public void onReceiveValue(String s) {
+                        processResponse(s);
+                    }
+                });
+            }
+
+            // wait for login page to load before attempting login redirect
+            if (url.contains("csp/gateway/discovery")) {
+                loaded = true;
+            }
+        }
+
+        private void processResponse (String s) {
+            try {
+                //alter string to remove double quotes and backslashes
+                s = s.replaceAll("^\"|\"$", "");
+                s = s.replaceAll("\\\\", "");
+
+                // derive access_token and token_type to make CspResult from response
+                JsonObject obj = new Gson().fromJson(s, JsonObject.class);
+                String access_token = obj.get("access_token").getAsString();
+                String token_type = obj.get("token_type").getAsString();
+                CspResult result = new CspResult(token_type, access_token);
+
+                if (access_token.isEmpty()) {
+                    throw new IllegalStateException("Access token for login could not be found.");
+                }
+
+                // add token to context
+                Context c = getBaseContext();
+                LoginModel.getInstance(c).setAuthenticated(true);
+                LoginModel.getInstance(c).setBearer_token(result.getToken());
+                startActivity(mainIntent);
+            } catch (Exception e){
+                toastMsg("Failed to retrieve login information. See Options to log in with an API token instead");
+            }
+
+        }
+    }
+
 }

--- a/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
@@ -27,7 +27,7 @@ public class CSPLoginActivity extends AppCompatActivity {
 
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
         Intent tokenIntent = new Intent(this, TokenLoginActivity.class);
-        if(settings.getBoolean(getApplicationContext().getResources().getString(R.string.catalog_source_property_name),
+        if(settings.getBoolean(getApplicationContext().getResources().getString(R.string.login_source_property_name),
                 false)) {
             startActivity(tokenIntent);
             finish();

--- a/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
@@ -1,0 +1,54 @@
+package com.vmware.nimbus.ui.login;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Bundle;
+import android.preference.PreferenceManager;
+import android.view.View;
+import android.webkit.WebView;
+import android.widget.Button;
+import android.widget.EditText;
+import android.widget.ProgressBar;
+import android.widget.Toast;
+
+import com.vmware.nimbus.R;
+import com.vmware.nimbus.ui.main.MainActivity;
+import com.vmware.nimbus.ui.main.OptionsActivity;
+
+public class CSPLoginActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_csplogin);
+
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        Intent tokenIntent = new Intent(this, TokenLoginActivity.class);
+        if(settings.getBoolean(getApplicationContext().getResources().getString(R.string.catalog_source_property_name),
+                false)) {
+            startActivity(tokenIntent);
+            finish();
+        }
+
+        WebView cspLoginPage = (WebView) findViewById(R.id.webview);
+        cspLoginPage.loadUrl("https://www.mgmt.cloud.vmware.com/catalog/#/library");
+
+        Intent optionsIntent = new Intent(this, OptionsActivity.class);
+        final Button optionsButton = findViewById(R.id.options);
+
+        optionsButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View view) {
+                startActivity(optionsIntent);
+            }
+        });
+    }
+
+    public static void toastMsg(String msg, Context c) {
+        Toast toast = Toast.makeText(c, msg, Toast.LENGTH_LONG);
+        toast.show();
+    }
+}

--- a/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/CSPLoginActivity.java
@@ -22,16 +22,10 @@ public class CSPLoginActivity extends AppCompatActivity {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
+        switchToTokenLoginIfSet();
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_csplogin);
-
-        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
-        Intent tokenIntent = new Intent(this, TokenLoginActivity.class);
-        if(settings.getBoolean(getApplicationContext().getResources().getString(R.string.login_source_property_name),
-                false)) {
-            startActivity(tokenIntent);
-            finish();
-        }
 
         WebView cspLoginPage = (WebView) findViewById(R.id.webview);
         cspLoginPage.loadUrl("https://www.mgmt.cloud.vmware.com/catalog/#/library");
@@ -47,8 +41,19 @@ public class CSPLoginActivity extends AppCompatActivity {
         });
     }
 
-    public static void toastMsg(String msg, Context c) {
-        Toast toast = Toast.makeText(c, msg, Toast.LENGTH_LONG);
-        toast.show();
+    @Override
+    protected void onResume() {
+        switchToTokenLoginIfSet();
+        super.onResume();
+    }
+
+    private void switchToTokenLoginIfSet() {
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        Intent tokenIntent = new Intent(this, TokenLoginActivity.class);
+        if(settings.getBoolean(getApplicationContext().getResources().getString(R.string.login_source_property_name),
+                false)) {
+            startActivity(tokenIntent);
+            finish();
+        }
     }
 }

--- a/app/src/main/java/com/vmware/nimbus/ui/login/TokenLoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/TokenLoginActivity.java
@@ -1,7 +1,9 @@
 package com.vmware.nimbus.ui.login;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
@@ -30,6 +32,8 @@ public class TokenLoginActivity extends AppCompatActivity {
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
+        switchToCSPLoginIfNotSet();
+
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_tokenlogin);
         Intent mainIntent = new Intent(this, MainActivity.class);
@@ -81,6 +85,22 @@ public class TokenLoginActivity extends AppCompatActivity {
     public void toastMsg(String msg) {
         Toast toast = Toast.makeText(getApplicationContext(), msg, Toast.LENGTH_SHORT);
         toast.show();
+    }
+
+    @Override
+    protected void onResume() {
+        switchToCSPLoginIfNotSet();
+        super.onResume();
+    }
+
+    private void switchToCSPLoginIfNotSet() {
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
+        Intent cspIntent = new Intent(this, CSPLoginActivity.class);
+        if(!settings.getBoolean(getApplicationContext().getResources().getString(R.string.login_source_property_name),
+                false)) {
+            startActivity(cspIntent);
+            finish();
+        }
     }
 
     @Override

--- a/app/src/main/java/com/vmware/nimbus/ui/login/TokenLoginActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/login/TokenLoginActivity.java
@@ -19,7 +19,7 @@ import androidx.appcompat.app.AppCompatActivity;
 /**
  * The login activity.
  */
-public class LoginActivity extends AppCompatActivity {
+public class TokenLoginActivity extends AppCompatActivity {
 
     String LOG_TAG = "LoginActivity";
 
@@ -31,7 +31,7 @@ public class LoginActivity extends AppCompatActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_login);
+        setContentView(R.layout.activity_tokenlogin);
         Intent mainIntent = new Intent(this, MainActivity.class);
         Intent optionsIntent = new Intent(this, OptionsActivity.class);
         final EditText apiKeyEditText = findViewById(R.id.password);

--- a/app/src/main/java/com/vmware/nimbus/ui/main/MainActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/main/MainActivity.java
@@ -10,7 +10,7 @@ import android.view.MenuItem;
 import com.google.android.material.tabs.TabLayout;
 import com.vmware.nimbus.R;
 import com.vmware.nimbus.api.APIService;
-import com.vmware.nimbus.ui.login.LoginActivity;
+import com.vmware.nimbus.ui.login.TokenLoginActivity;
 import com.vmware.nimbus.ui.main.adapters.SectionsPagerAdapter;
 
 import androidx.appcompat.app.AppCompatActivity;
@@ -60,7 +60,7 @@ public class MainActivity extends AppCompatActivity {
     public void LogOut() {
         APIService.LogOut(getBaseContext());
 
-        Intent intent1 = new Intent(MainActivity.this, LoginActivity.class);
+        Intent intent1 = new Intent(MainActivity.this, TokenLoginActivity.class);
         intent1.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
         startActivity(intent1);
         finish();

--- a/app/src/main/java/com/vmware/nimbus/ui/main/OptionsActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/main/OptionsActivity.java
@@ -23,17 +23,17 @@ public class OptionsActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_options);
+
+        final Switch catalogSource = findViewById(R.id.catalogSwitch);
+        final Switch loginSource = findViewById(R.id.loginSwitch);
+        final Button saveButton = findViewById(R.id.save);
+        final EditText rootUri = findViewById(R.id.rootUri);
         SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(getApplicationContext());
 
         String currentBaseUrl = settings.getString(getApplicationContext().getResources().getString(R.string.base_url_shared_property_name), null);
         if (currentBaseUrl != null && !currentBaseUrl.equals("")) {
-            ((EditText)findViewById(R.id.rootUri)).setText(currentBaseUrl);
+            rootUri.setText(currentBaseUrl);
         }
-
-        final Switch catalogSource = findViewById(R.id.catalogSwitch);
-
-        final Switch loginSource = findViewById(R.id.loginSwitch);
-
 
         catalogSource.setChecked(settings.getBoolean(
                 getApplicationContext().getResources().getString(R.string.catalog_source_property_name),
@@ -62,10 +62,25 @@ public class OptionsActivity extends AppCompatActivity {
                         getApplicationContext().getResources().getString(R.string.login_source_property_name),
                         isChecked
                 ).apply();
+
+                if(isChecked) {
+                    saveButton.setEnabled(true);
+                    rootUri.setEnabled(true);
+                } else {
+                    saveButton.setEnabled(false);
+                    rootUri.setEnabled(false);
+                }
             }
         });
 
-        final Button saveButton = findViewById(R.id.save);
+        if(!settings.getBoolean(getApplicationContext().getResources().getString(R.string.login_source_property_name),
+                false)) {
+            saveButton.setEnabled(false);
+            rootUri.setEnabled(false);
+        } else {
+            saveButton.setEnabled(true);
+            rootUri.setEnabled(true);
+        }
 
         saveButton.setOnClickListener(new View.OnClickListener() {
             @Override
@@ -73,7 +88,7 @@ public class OptionsActivity extends AppCompatActivity {
 
                 settings.edit().putString(
                         getApplicationContext().getResources().getString(R.string.base_url_shared_property_name),
-                        ((EditText)findViewById(R.id.rootUri)).getText().toString()
+                        rootUri.getText().toString()
                 ).apply();
                 toastMsg("Saved Settings", getApplicationContext());
             }
@@ -88,7 +103,7 @@ public class OptionsActivity extends AppCompatActivity {
                 settings.edit().remove(
                         getApplicationContext().getResources().getString(R.string.base_url_shared_property_name)
                 ).apply();
-                ((EditText)findViewById(R.id.rootUri)).setText(getApplicationContext().getResources().getString(R.string.base_url));
+                rootUri.setText(getApplicationContext().getResources().getString(R.string.base_url));
                 toastMsg("Restored Settings", getApplicationContext());
             }
         });

--- a/app/src/main/java/com/vmware/nimbus/ui/main/OptionsActivity.java
+++ b/app/src/main/java/com/vmware/nimbus/ui/main/OptionsActivity.java
@@ -32,8 +32,16 @@ public class OptionsActivity extends AppCompatActivity {
 
         final Switch catalogSource = findViewById(R.id.catalogSwitch);
 
+        final Switch loginSource = findViewById(R.id.loginSwitch);
+
+
         catalogSource.setChecked(settings.getBoolean(
                 getApplicationContext().getResources().getString(R.string.catalog_source_property_name),
+                false
+        ));
+
+        loginSource.setChecked(settings.getBoolean(
+                getApplicationContext().getResources().getString(R.string.login_source_property_name),
                 false
         ));
 
@@ -42,6 +50,16 @@ public class OptionsActivity extends AppCompatActivity {
             public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
                 settings.edit().putBoolean(
                         getApplicationContext().getResources().getString(R.string.catalog_source_property_name),
+                        isChecked
+                ).apply();
+            }
+        });
+
+        loginSource.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+            @Override
+            public void onCheckedChanged(CompoundButton compoundButton, boolean isChecked) {
+                settings.edit().putBoolean(
+                        getApplicationContext().getResources().getString(R.string.login_source_property_name),
                         isChecked
                 ).apply();
             }

--- a/app/src/main/res/layout/activity_csplogin.xml
+++ b/app/src/main/res/layout/activity_csplogin.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.login.CSPLoginActivity">
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        />
+
+    <Button
+        android:id="@+id/options"
+        style="@style/Widget.MaterialComponents.Button.TextButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:text="@string/action_options"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.498"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/webview"
+        app:layout_constraintVertical_bias="0.95" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_csplogin.xml
+++ b/app/src/main/res/layout/activity_csplogin.xml
@@ -10,6 +10,8 @@
         android:id="@+id/webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
+        android:layout_marginBottom="50dp"
+        app:layout_constraintTop_toTopOf="parent"
         />
 
     <Button

--- a/app/src/main/res/layout/activity_options.xml
+++ b/app/src/main/res/layout/activity_options.xml
@@ -13,7 +13,20 @@
         android:text="Use API Token Authentication"
         app:layout_constraintBottom_toTopOf="@+id/rootUriLabel"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"/>
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Switch
+        android:id="@+id/catalogSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="@string/catalog_source_text"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/loginSwitch"
+        app:layout_constraintStart_toStartOf="@+id/loginSwitch"
+        app:layout_constraintTop_toBottomOf="@+id/loginSwitch"
+        app:layout_constraintVertical_bias="0.0" />
 
     <TextView
         android:id="@+id/rootUriLabel"
@@ -32,21 +45,9 @@
         android:text="@string/base_url"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/catalogSwitch"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.185" />
-
-    <Switch
-        android:id="@+id/catalogSwitch"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="24dp"
-        android:text="@string/catalog_source_text"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="@+id/rootUri"
-        app:layout_constraintStart_toStartOf="@+id/rootUri"
-        app:layout_constraintTop_toBottomOf="@+id/rootUri"
-        app:layout_constraintVertical_bias="0.0" />
+        app:layout_constraintVertical_bias="0.2" />
 
     <Button
         android:id="@+id/save"
@@ -56,7 +57,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="@+id/rootUri"
         app:layout_constraintStart_toStartOf="@+id/rootUri"
-        app:layout_constraintTop_toBottomOf="@+id/catalogSwitch"
+        app:layout_constraintTop_toBottomOf="@+id/rootUri"
         app:layout_constraintVertical_bias="0.05" />
 
     <Button

--- a/app/src/main/res/layout/activity_options.xml
+++ b/app/src/main/res/layout/activity_options.xml
@@ -6,6 +6,15 @@
     android:layout_height="match_parent"
     tools:context=".ui.main.OptionsActivity">
 
+    <Switch
+        android:id="@+id/loginSwitch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Use API Token Authentication"
+        app:layout_constraintBottom_toTopOf="@+id/rootUriLabel"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"/>
+
     <TextView
         android:id="@+id/rootUriLabel"
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_tokenlogin.xml
+++ b/app/src/main/res/layout/activity_tokenlogin.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:background="@drawable/background"
     android:orientation="vertical"
-    tools:context=".ui.login.LoginActivity">
+    tools:context=".ui.login.TokenLoginActivity">
 
     <androidx.cardview.widget.CardView
         android:id="@+id/cardView"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="base_url_english_name">Endpoint Base URL</string>
 
     <string name="catalog_source_property_name">catalog_source</string>
-    <string name="login_source_property_name">catalog_source</string>
+    <string name="login_source_property_name">login_source</string>
 
     <string name="catalog_source_text">Only source published catalog items</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="base_url_english_name">Endpoint Base URL</string>
 
     <string name="catalog_source_property_name">catalog_source</string>
+    <string name="login_source_property_name">catalog_source</string>
+
     <string name="catalog_source_text">Only source published catalog items</string>
 
     <string name="base_url">https://api.mgmt.cloud.vmware.com</string>


### PR DESCRIPTION
Adding CSP login as an option, which will now be the default. This is modeled after the same login process currently available in the iOs version of the app, where an attempt to access "https://www.mgmt.cloud.vmware.com/catalog/#/library" is allowed to redirect to a login page, and an access token is retrieved after successful login. 

This merge request is made to follow "Add option to toggle between csp and token authentication #128", as it incorporates code used in the toggling.